### PR TITLE
Fixed autoload definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "silex/silex": ">=1.0.0-dev"
     },
     "autoload": {
-        "psr0": {
+        "psr-0": {
             "Igorw": "src"
         }
     }


### PR DESCRIPTION
Noticed that the autoload_namespaces.php file wasn't including this library. Turned out a hyphen is missing in the "psr-0" key, which makes Composer ignore it.
