### PR TITLE
define the ConfigServiceProvider::boot() method

### DIFF
--- a/src/Igorw/Silex/ConfigServiceProvider.php
+++ b/src/Igorw/Silex/ConfigServiceProvider.php
@@ -40,6 +40,10 @@ class ConfigServiceProvider implements ServiceProviderInterface
         }
     }
 
+    public function boot(Application $app)
+    {
+    }
+
     private function doReplacements($value)
     {
         if (!$this->replacements) {


### PR DESCRIPTION
to respect the change in Silex ServiceProviderInterface (see https://github.com/fabpot/Silex/pull/330).
