### PR TITLE
Deformed values. 

### DIFF
--- a/src/Igorw/Silex/ConfigServiceProvider.php
+++ b/src/Igorw/Silex/ConfigServiceProvider.php
@@ -58,7 +58,7 @@ class ConfigServiceProvider implements ServiceProviderInterface
             return $value;
         }
 
-        return strtr($value, $this->replacements);
+        return is_string($value) ? strtr($value, $this->replacements) : $value;
     }
 
     private function readConfig()


### PR DESCRIPTION
ConfigServiceProvider::doReplacements deformed values which wasn't strings. 
For examble boolean false became empty string. 
