### PR TITLE
Replacements in config.

### DIFF
--- a/src/Igorw/Silex/ConfigServiceProvider.php
+++ b/src/Igorw/Silex/ConfigServiceProvider.php
@@ -35,6 +35,10 @@ class ConfigServiceProvider implements ServiceProviderInterface
     {
         $config = $this->readConfig();
 
+        foreach( $config as $name => $value )
+            if ( substr( $name, 0, 1 ) == '%' )
+                $this->replacements[ $name ] = (string) $value;
+
         foreach ($config as $name => $value) {
             $app[$name] = $this->doReplacements($value);
         }

--- a/tests/Igorw/Silex/Tests/ConfigServiceProviderTest.php
+++ b/tests/Igorw/Silex/Tests/ConfigServiceProviderTest.php
@@ -117,4 +117,34 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
             $readConfigMethod->invoke(new ConfigServiceProvider(__DIR__."/Fixtures/empty_config.yml"))
         );
     }
+
+    public function testRegisterJsonWithReplacementInJsonFile()
+    {
+        $app = new Application();
+
+        $app->register(new ConfigServiceProvider(__DIR__."/Fixtures/config_replacement.json"));
+
+        $this->assertSame( '/var/www', $app['%path%']);
+        $this->assertSame( '/var/www/web/images', $app['path.images']);
+        $this->assertSame( '/var/www/upload', $app[ 'path.upload' ]);
+        $this->assertSame( 'http://example.com', $app['%url%']);
+        $this->assertSame( 'http://example.com/images', $app['url.images']);
+    }
+
+    public function testRegisterYamlWithReplacementInYamlFile()
+    {
+        if (!class_exists('Symfony\\Component\\Yaml\\Yaml')) {
+            $this->markTestIncomplete();
+        }
+
+        $app = new Application();
+
+        $app->register(new ConfigServiceProvider(__DIR__."/Fixtures/config_replacement.yml"));
+
+        $this->assertSame( '/var/www', $app['%path%']);
+        $this->assertSame( '/var/www/web/images', $app['path.images']);
+        $this->assertSame( '/var/www/upload', $app[ 'path.upload' ]);
+        $this->assertSame( 'http://example.com', $app['%url%']);
+        $this->assertSame( 'http://example.com/images', $app['url.images']);
+    }
 }

--- a/tests/Igorw/Silex/Tests/Fixtures/config_replacement.json
+++ b/tests/Igorw/Silex/Tests/Fixtures/config_replacement.json
@@ -1,0 +1,7 @@
+{
+  "%path%": "/var/www",
+  "path.images": "%path%/web/images",
+  "path.upload": "%path%/upload",
+  "%url%": "http://example.com",
+  "url.images": "%url%/images"
+}

--- a/tests/Igorw/Silex/Tests/Fixtures/config_replacement.yml
+++ b/tests/Igorw/Silex/Tests/Fixtures/config_replacement.yml
@@ -1,0 +1,5 @@
+%path%: /var/www
+path.images: %path%/web/images
+path.upload: %path%/upload
+%url%: "http://example.com"
+url.images: "%url%/images"


### PR DESCRIPTION
This patch allow to define replacements in config file:

YAML:
%app.path%: "d:\dbaltest"
monolog.logfile: "%app.path%/logs/debug.log"
