### PR TITLE
Object properties are merged when using more than one JSON file

### DIFF
--- a/src/Igorw/Silex/ConfigServiceProvider.php
+++ b/src/Igorw/Silex/ConfigServiceProvider.php
@@ -40,16 +40,23 @@ class ConfigServiceProvider implements ServiceProviderInterface
                 $this->replacements[$name] = (string) $value;
 
         foreach ($config as $name => $value) {
-			if (isset($app[$name])){
-				$arr = $app[$name];
-				foreach($value as $sub_name => $sub_value) {
-					$arr[$sub_name] = $this->doReplacements($sub_value);
-				}
-				$app[$name] = $arr;
-			}else{
-				$app[$name] = $this->doReplacements($value);
-			}
+            if (isset($app[$name])){
+                $app[$name] = $this->loop($app[$name],$value);
+            }else{
+                $app[$name] = $this->doReplacements($value);
+            }
         }
+    }
+
+    private function loop($arr, $value) {
+        foreach($value as $sub_name => $sub_value) {
+            if (is_array($sub_value)){
+                $arr[$sub_name] = $this->loop($arr[$sub_name],$sub_value);
+            }else{
+                $arr[$sub_name] = $this->doReplacements($sub_value);
+            }
+        }
+        return $arr;
     }
 
     public function boot(Application $app)

--- a/src/Igorw/Silex/ConfigServiceProvider.php
+++ b/src/Igorw/Silex/ConfigServiceProvider.php
@@ -40,7 +40,7 @@ class ConfigServiceProvider implements ServiceProviderInterface
                 $this->replacements[$name] = (string) $value;
 
         foreach ($config as $name => $value) {
-            if (isset($app[$name])){
+            if (isset($app[$name]) && is_array($value)){
                 $app[$name] = $this->loop($app[$name],$value);
             }else{
                 $app[$name] = $this->doReplacements($value);

--- a/src/Igorw/Silex/ConfigServiceProvider.php
+++ b/src/Igorw/Silex/ConfigServiceProvider.php
@@ -40,7 +40,15 @@ class ConfigServiceProvider implements ServiceProviderInterface
                 $this->replacements[$name] = (string) $value;
 
         foreach ($config as $name => $value) {
-            $app[$name] = $this->doReplacements($value);
+			if (isset($app[$name])){
+				$arr = $app[$name];
+				foreach($value as $sub_name => $sub_value) {
+					$arr[$sub_name] = $this->doReplacements($sub_value);
+				}
+				$app[$name] = $arr;
+			}else{
+				$app[$name] = $this->doReplacements($value);
+			}
         }
     }
 

--- a/tests/Igorw/Silex/Tests/ConfigServiceProviderTest.php
+++ b/tests/Igorw/Silex/Tests/ConfigServiceProviderTest.php
@@ -78,6 +78,31 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('http://example.com/images', $app['url.images']);
     }
 
+    /**
+     * @dataProvider provideMergeFilenames
+     */
+    public function testMergeConfigs($filenameBase, $filenameExtended)
+    {
+        $app = new Application();
+        $app->register(new ConfigServiceProvider($filenameBase));
+        $app->register(new ConfigServiceProvider($filenameExtended));
+
+        $this->assertSame('pdo_mysql', $app['db.options']['driver']);
+        $this->assertSame('utf8', $app['db.options']['charset']);
+        $this->assertSame('127.0.0.1', $app['db.options']['host']);
+        $this->assertSame('mydatabase', $app['db.options']['dbname']);
+        $this->assertSame('root', $app['db.options']['user']);
+        $this->assertSame(NULL, $app['db.options']['password']);
+
+        $this->assertSame("123", $app['myproject.test']['param1']);
+        $this->assertSame("456", $app['myproject.test']['param2']);
+        $this->assertSame("123", $app['myproject.test']['param3']['param2A']);
+        $this->assertSame("456", $app['myproject.test']['param3']['param2B']);
+        $this->assertSame("456", $app['myproject.test']['param3']['param2C']);
+        $this->assertSame(array(4,5,6), $app['myproject.test']['param4']);
+        $this->assertSame("456", $app['myproject.test']['param5']);
+    }
+
     public function provideFilenames()
     {
         return array(
@@ -102,6 +127,15 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
             array(__DIR__."/Fixtures/config_empty.php"),
             array(__DIR__."/Fixtures/config_empty.json"),
             array(__DIR__."/Fixtures/config_empty.yml"),
+        );
+    }
+
+    public function provideMergeFilenames()
+    {
+        return array(
+            array(__DIR__."/Fixtures/config_base.php",__DIR__."/Fixtures/config_extend.php"),
+            array(__DIR__."/Fixtures/config_base.json",__DIR__."/Fixtures/config_extend.json"),
+            array(__DIR__."/Fixtures/config_base.yml",__DIR__."/Fixtures/config_extend.yml")
         );
     }
 

--- a/tests/Igorw/Silex/Tests/Fixtures/config_base.json
+++ b/tests/Igorw/Silex/Tests/Fixtures/config_base.json
@@ -1,0 +1,15 @@
+{
+	"db.options":{
+		"driver":"pdo_mysql",
+		"charset":"utf8"
+	},
+	"myproject.test":{
+		"param1":"123",
+		"param2":"123",
+		"param3":{
+			"param2A":"123",
+			"param2B":"123"
+		},
+		"param4":[1,2,3]
+	}
+}

--- a/tests/Igorw/Silex/Tests/Fixtures/config_base.php
+++ b/tests/Igorw/Silex/Tests/Fixtures/config_base.php
@@ -1,0 +1,17 @@
+<?php
+
+return array(
+    'db.options' => array(
+        'driver' => 'pdo_mysql',
+		'charset' => 'utf8'
+    ),
+    'myproject.test' => array(
+        'param1' => '123',
+        'param2' => '123',
+        'param3' => array(
+            'param2A' => '123',
+            'param2B' => '123'
+        ),
+        'param4' => array(1,2,3)
+     )
+);

--- a/tests/Igorw/Silex/Tests/Fixtures/config_base.yml
+++ b/tests/Igorw/Silex/Tests/Fixtures/config_base.yml
@@ -1,0 +1,10 @@
+db.options:
+  driver : pdo_mysql
+  charset : utf8
+myproject.test:
+  param1 : "123"
+  param2 : "123"
+  param3:
+    param2A : "123"
+    param2B : "123"
+  param4 : [1,2,3]

--- a/tests/Igorw/Silex/Tests/Fixtures/config_extend.json
+++ b/tests/Igorw/Silex/Tests/Fixtures/config_extend.json
@@ -1,0 +1,17 @@
+{
+	"db.options":{
+		"host":"127.0.0.1",
+		"dbname":"mydatabase",
+		"user":"root",
+		"password":null
+	},
+	"myproject.test":{
+		"param2":"456",
+		"param3":{
+			"param2B":"456",
+			"param2C":"456"
+		},
+		"param4":[4,5,6],
+		"param5":"456"
+	}
+}

--- a/tests/Igorw/Silex/Tests/Fixtures/config_extend.php
+++ b/tests/Igorw/Silex/Tests/Fixtures/config_extend.php
@@ -1,0 +1,19 @@
+<?php
+
+return array(
+    'db.options' => array(
+        'host' => '127.0.0.1',
+		'dbname' => 'mydatabase',
+		'user' => 'root',
+		'password' => NULL
+    ),
+    'myproject.test' => array(
+        'param2' => '456',
+        'param3' => array(
+            'param2B' => '456',
+            'param2C' => '456'
+        ),
+        'param4' => array(4,5,6),
+        'param5' => '456'
+    )
+);

--- a/tests/Igorw/Silex/Tests/Fixtures/config_extend.yml
+++ b/tests/Igorw/Silex/Tests/Fixtures/config_extend.yml
@@ -1,0 +1,12 @@
+db.options:
+  host : 127.0.0.1
+  dbname : mydatabase
+  user : root
+  password :
+myproject.test:
+  param2 : "456"
+  param3:
+    param2B : "456"
+    param2C : "456"
+  param4 : [4,5,6]
+  param5 : "456"


### PR DESCRIPTION
When two configs are used (e.g. a config_base.json and then an environment-specific config file) the subsequent config file is merged with the first so that properties aren't lost.

Below is an example of loading one base config file, and then loading an environment-specific config that overrides _some_ of the properties, adds new ones that don't exist, and doesn't delete properties that aren't used in the "extended" json file. Notice that arrays, as intended, will overwrite each other as opposed to merging like object properties do.

config_base.json:

``` json
{"test":{
  "value1":"a",
  "value2":"a",
  "object1":{
    "value1":"a",
    "value2":"a",
    "sub1":{
      "value1":"a",
      "value2":"a"
    }
  },
  "array":["a1","a2"]
}}
```

config_local.json:

``` json
{"test":{
  "value2":"b",
  "value3":"b",
  "object1":{
    "value2":"b",
    "value3":"b",
    "sub1":{
      "value2":"b",
      "value3":"b"
    }
  },
  "array":["b1","b2"]
}}
```

combined result:

``` json
{"test":{
  "value1": "a",
  "value2": "b",
  "value3": "b",
  "object1": {
    "value1": "a",
    "value2": "b",
    "value3": "b",
    "sub1": {
      "value1": "a",
      "value2": "b",
      "value3": "b"
    }
  },
  "array": ["b1","b2"]
}}
```
