### PR TITLE
Fix problem with array value in new config

### DIFF
--- a/src/Igorw/Silex/ConfigServiceProvider.php
+++ b/src/Igorw/Silex/ConfigServiceProvider.php
@@ -84,7 +84,7 @@ class ConfigServiceProvider implements ServiceProviderInterface
     private function mergeRecursively(array $currentValue, array $newValue)
     {
         foreach ($newValue as $name => $value) {
-            if (is_array($value)) {
+            if (is_array($value) && isset($currentValue[$name])) {
                 $currentValue[$name] = $this->mergeRecursively($currentValue[$name], $value);
             } else {
                 $currentValue[$name] = $this->doReplacements($value);

--- a/tests/integration/ConfigServiceProviderTest.php
+++ b/tests/integration/ConfigServiceProviderTest.php
@@ -99,6 +99,9 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('456', $app['myproject.test']['param3']['param2C']);
         $this->assertSame(array(4, 5, 6), $app['myproject.test']['param4']);
         $this->assertSame('456', $app['myproject.test']['param5']);
+        
+        $this->assertSame(array(1,2,3,4), $app['test.noparent.key']['test']);
+
     }
 
     /**

--- a/tests/integration/Fixtures/config_base.json
+++ b/tests/integration/Fixtures/config_base.json
@@ -11,5 +11,6 @@
             "param2B": "123"
         },
         "param4": [1, 2, 3]
-    }
+    },
+    "test.noparent.key" : {}
 }

--- a/tests/integration/Fixtures/config_base.php
+++ b/tests/integration/Fixtures/config_base.php
@@ -14,4 +14,5 @@ return array(
         ),
         'param4' => array(1, 2, 3),
      ),
+     "test.noparent.key" => array(),
 );

--- a/tests/integration/Fixtures/config_base.yml
+++ b/tests/integration/Fixtures/config_base.yml
@@ -8,3 +8,5 @@ myproject.test:
     param2A: "123"
     param2B: "123"
   param4: [1, 2, 3]
+test.noparent.key: 
+  IDontKnowAnyThingAboutYAML: []

--- a/tests/integration/Fixtures/config_extend.json
+++ b/tests/integration/Fixtures/config_extend.json
@@ -13,5 +13,9 @@
         },
         "param4": [4, 5, 6],
         "param5": "456"
+    },
+    
+    "test.noparent.key" : {
+		"test": [1,2,3,4]
     }
 }

--- a/tests/integration/Fixtures/config_extend.php
+++ b/tests/integration/Fixtures/config_extend.php
@@ -16,4 +16,7 @@ return array(
         'param4' => array(4, 5, 6),
         'param5' => '456',
     ),
+    "test.noparent.key" => array(
+		"test" => array(1,2,3,4)
+    ),
 );

--- a/tests/integration/Fixtures/config_extend.yml
+++ b/tests/integration/Fixtures/config_extend.yml
@@ -10,3 +10,5 @@ myproject.test:
     param2C: "456"
   param4: [4, 5, 6]
   param5: "456"
+test.noparent.key:
+  test: [1,2,3,4]


### PR DESCRIPTION
If I have an empty base config (like {} ) and then load a NEW config like thie : 

```
{
 "key" : {"this": 1, "that" :2}
}
```

I get an error, since the key is not exist in base config. 
