### PR TITLE
Yaml imports support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,15 @@ config data, and also make sure it ends with `.php`:
 You can use multiple config files, e. g. one for a whole application and a
 specific one for a task by calling `$app->register()` several times, each time
 passing another instance of `Igorw\Silex\ConfigServiceProvider`.
+
+
+### Multiple config files with YAML
+
+You can use the `imports` declaration to import multiple config files into one file
+
+    imports:
+        - { resource: config.yml }
+        - { resource: parameters_dev.yml }
+        - { resource: db/db_dev.yml }
+
+    debug: true

--- a/src/Igorw/Silex/YamlConfigDriver.php
+++ b/src/Igorw/Silex/YamlConfigDriver.php
@@ -12,11 +12,35 @@ class YamlConfigDriver implements ConfigDriver
             throw new \RuntimeException('Unable to read yaml as the Symfony Yaml Component is not installed.');
         }
         $config = Yaml::parse($filename);
+        $config = $this->loadImports($config, $filename);
+
         return $config ?: array();
     }
 
     public function supports($filename)
     {
         return (bool) preg_match('#\.ya?ml(\.dist)?$#', $filename);
+    }
+
+    public function loadImports($config, $filename)
+    {
+        if (isset($config['imports']) && is_array($config['imports'])) {
+            $path = pathinfo($filename);
+            $imports = $config['imports'];
+            unset($config['imports']);
+
+            $importedConfig = array();
+            foreach ($imports as $import) {
+                $file = $path['dirname'] . '/' . $import['resource'];
+
+                if (is_file($file)) {
+                    $imported = $this->load($file);
+                    $importedConfig = array_merge($importedConfig, $imported);
+                }
+            }
+            $config = array_merge($config, $importedConfig);
+        }
+
+        return $config;
     }
 }

--- a/src/Igorw/Silex/YamlConfigDriver.php
+++ b/src/Igorw/Silex/YamlConfigDriver.php
@@ -38,7 +38,7 @@ class YamlConfigDriver implements ConfigDriver
                     $importedConfig = array_merge($importedConfig, $imported);
                 }
             }
-            $config = array_merge($config, $importedConfig);
+            $config = array_merge($importedConfig, $config);
         }
 
         return $config;


### PR DESCRIPTION
Using a yaml config file, you will be able to import resources instead of reinstantiating the ConfigServiceProvider for multiple config files.
