### PR TITLE
Add support for configuration prefixes

### DIFF
--- a/src/Igorw/Silex/ConfigServiceProvider.php
+++ b/src/Igorw/Silex/ConfigServiceProvider.php
@@ -55,10 +55,10 @@ class ConfigServiceProvider implements ServiceProviderInterface
     {
     }
 
-    private function merge(Application $app, array $config, $prefix = null)
+    private function merge(Application $app, array $config)
     {
-        if ($prefix = $prefix ?: $this->prefix) {
-            $config = array($prefix => $config);
+        if ($this->prefix) {
+            $config = array($this->prefix => $config);
         }
 
         foreach ($config as $name => $value) {

--- a/src/Igorw/Silex/ConfigServiceProvider.php
+++ b/src/Igorw/Silex/ConfigServiceProvider.php
@@ -19,10 +19,12 @@ class ConfigServiceProvider implements ServiceProviderInterface
     private $filename;
     private $replacements = array();
     private $driver;
+    private $prefix = null;
 
-    public function __construct($filename, array $replacements = array(), ConfigDriver $driver = null)
+    public function __construct($filename, array $replacements = array(), ConfigDriver $driver = null, $prefix = null)
     {
         $this->filename = $filename;
+        $this->prefix = $prefix;
 
         if ($replacements) {
             foreach ($replacements as $key => $value) {
@@ -53,8 +55,12 @@ class ConfigServiceProvider implements ServiceProviderInterface
     {
     }
 
-    private function merge(Application $app, array $config)
+    private function merge(Application $app, array $config, $prefix = null)
     {
+        if ($prefix = $prefix ?: $this->prefix) {
+            $config = array($prefix => $config);
+        }
+
         foreach ($config as $name => $value) {
             if (isset($app[$name]) && is_array($value)) {
                 $app[$name] = $this->mergeRecursively($app[$name], $value);


### PR DESCRIPTION
This pull request gives the option to put the configuration data on an arbitrary key of `$app` (say, `$app['config']` or `$app['data']`), instead of loading the data directly to `$app`.

An extra optional parameter was added to `ConfigServiceProvider`'s constructor to pass the prefixes.

It doesn't support nested prefixes (ie: `['config']['dev']`). But `config.dev` and similar can be used instead.
