### PR TITLE
allow merging of string and array values for config keys

### DIFF
--- a/src/Igorw/Silex/ConfigDriver.php
+++ b/src/Igorw/Silex/ConfigDriver.php
@@ -4,6 +4,6 @@ namespace Igorw\Silex;
 
 interface ConfigDriver
 {
-    function load($filename);
-    function supports($filename);
+    public function load($filename);
+    public function supports($filename);
 }

--- a/src/Igorw/Silex/ConfigServiceProvider.php
+++ b/src/Igorw/Silex/ConfigServiceProvider.php
@@ -42,9 +42,11 @@ class ConfigServiceProvider implements ServiceProviderInterface
     {
         $config = $this->readConfig();
 
-        foreach ($config as $name => $value)
-            if ('%' === substr($name, 0, 1))
+        foreach ($config as $name => $value) {
+            if ('%' === substr($name, 0, 1)) {
                 $this->replacements[$name] = (string) $value;
+            }
+        }
 
         $this->merge($app, $config);
     }
@@ -57,7 +59,10 @@ class ConfigServiceProvider implements ServiceProviderInterface
     {
         foreach ($config as $name => $value) {
             if (isset($app[$name]) && is_array($value)) {
-                $app[$name] = $this->mergeRecursively($app[$name], $value);
+                $app[$name] = $this->mergeRecursively(
+                    !is_array($app[$name]) ? array($app[$name]) : $app[$name],
+                    $value
+                );
             } else {
                 $app[$name] = $this->doReplacements($value);
             }
@@ -66,9 +71,16 @@ class ConfigServiceProvider implements ServiceProviderInterface
 
     private function mergeRecursively(array $currentValue, array $newValue)
     {
+        if (empty($newValue)) {
+            return $newValue;
+        }
+
         foreach ($newValue as $name => $value) {
             if (is_array($value) && isset($currentValue[$name])) {
-                $currentValue[$name] = $this->mergeRecursively($currentValue[$name], $value);
+                $currentValue[$name] = $this->mergeRecursively(
+                    !is_array($currentValue[$name]) ? array($currentValue[$name]) : $currentValue[$name],
+                    $value
+                );
             } else {
                 $currentValue[$name] = $this->doReplacements($value);
             }
@@ -106,7 +118,8 @@ class ConfigServiceProvider implements ServiceProviderInterface
 
         if (!file_exists($this->filename)) {
             throw new \InvalidArgumentException(
-                sprintf("The config file '%s' does not exist.", $this->filename));
+                sprintf("The config file '%s' does not exist.", $this->filename)
+            );
         }
 
         if ($this->driver->supports($this->filename)) {
@@ -114,6 +127,7 @@ class ConfigServiceProvider implements ServiceProviderInterface
         }
 
         throw new \InvalidArgumentException(
-                sprintf("The config file '%s' appears to have an invalid format.", $this->filename));
+            sprintf("The config file '%s' appears to have an invalid format.", $this->filename)
+        );
     }
 }

--- a/src/Igorw/Silex/JsonConfigDriver.php
+++ b/src/Igorw/Silex/JsonConfigDriver.php
@@ -11,7 +11,8 @@ class JsonConfigDriver implements ConfigDriver
         if (JSON_ERROR_NONE !== json_last_error()) {
             $jsonError = $this->getJsonError(json_last_error());
             throw new \RuntimeException(
-                sprintf('Invalid JSON provided "%s" in "%s"', $jsonError, $filename));
+                sprintf('Invalid JSON provided "%s" in "%s"', $jsonError, $filename)
+            );
         }
 
         return $config ?: array();

--- a/tests/integration/ConfigServiceProviderTest.php
+++ b/tests/integration/ConfigServiceProviderTest.php
@@ -130,6 +130,8 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('456', $app['myproject.test']['param5']);
 
         $this->assertSame(array(1,2,3,4), $app['test.noparent.key']['test']);
+        $this->assertSame(array('bar', 'baz'), $app['test.string.to.array']);
+        $this->assertSame(array(), $app['test.string.to.empty.array']);
     }
 
     /**

--- a/tests/integration/Fixtures/config_base.json
+++ b/tests/integration/Fixtures/config_base.json
@@ -12,5 +12,7 @@
         },
         "param4": [1, 2, 3]
     },
-    "test.noparent.key" : {}
+    "test.noparent.key": {},
+    "test.string.to.array": "foo",
+    "test.string.to.empty.array": "foo"
 }

--- a/tests/integration/Fixtures/config_base.php
+++ b/tests/integration/Fixtures/config_base.php
@@ -13,6 +13,8 @@ return array(
             'param2B' => '123',
         ),
         'param4' => array(1, 2, 3),
-     ),
-     'test.noparent.key' => array(),
+    ),
+    'test.noparent.key' => array(),
+    'test.string.to.array' => 'foo',
+    'test.string.to.empty.array' => 'foo'
 );

--- a/tests/integration/Fixtures/config_base.yml
+++ b/tests/integration/Fixtures/config_base.yml
@@ -10,3 +10,5 @@ myproject.test:
   param4: [1, 2, 3]
 test.noparent.key:
   IDontKnowAnyThingAboutYAML: {}
+test.string.to.array: "foo"
+test.string.to.empty.array: "foo"

--- a/tests/integration/Fixtures/config_extend.json
+++ b/tests/integration/Fixtures/config_extend.json
@@ -16,5 +16,7 @@
     },
     "test.noparent.key": {
         "test": [1, 2, 3, 4]
-    }
+    },
+    "test.string.to.array": ["bar", "baz"],
+    "test.string.to.empty.array": []
 }

--- a/tests/integration/Fixtures/config_extend.php
+++ b/tests/integration/Fixtures/config_extend.php
@@ -5,7 +5,7 @@ return array(
         'host' => '127.0.0.1',
         'dbname' => 'mydatabase',
         'user' => 'root',
-        'password' => NULL,
+        'password' => null,
     ),
     'myproject.test' => array(
         'param2' => '456',
@@ -19,4 +19,9 @@ return array(
     'test.noparent.key' => array(
         'test' => array(1, 2, 3, 4),
     ),
+    'test.string.to.array' => array(
+        'bar',
+        'baz'
+    ),
+    'test.string.to.empty.array' => array()
 );

--- a/tests/integration/Fixtures/config_extend.yml
+++ b/tests/integration/Fixtures/config_extend.yml
@@ -12,3 +12,5 @@ myproject.test:
   param5: "456"
 test.noparent.key:
   test: [1, 2, 3, 4]
+test.string.to.array: ["bar", "baz"]
+test.string.to.empty.array: []


### PR DESCRIPTION
Could not merge a config key that accepted both a string or array value (default provided was a string, my value was an array). This is my proposed solution. Cannot say with confidence it is elegant or desirable to allow this however. Please close PR if you do not agree or see a valid use case for this behavior.

Also, some CS/PSR2 thingies "fixed".
