### PR TITLE
Update the Yaml driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To use Yaml instead of JSON, just pass a file that ends on `.yml`:
 
     $app->register(new Igorw\Silex\ConfigServiceProvider(__DIR__."/../config/services.yml"));
 
-Note, you will have to require the `~2.1` of the `symfony/yaml` package.
+Note, you will have to require the `~2.2` of the `symfony/yaml` package.
 
 ### Using TOML
 

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
         "silex/silex": "~1.0"
     },
     "require-dev": {
-        "symfony/yaml": "~2.1",
+        "symfony/yaml": "~2.2",
         "jamesmoss/toml": "~0.1"
     },
     "suggest": {
-        "symfony/yaml": "~2.1",
+        "symfony/yaml": "~2.2",
         "jamesmoss/toml": "~0.1"
     },
     "autoload": {

--- a/src/Igorw/Silex/YamlConfigDriver.php
+++ b/src/Igorw/Silex/YamlConfigDriver.php
@@ -11,7 +11,9 @@ class YamlConfigDriver implements ConfigDriver
         if (!class_exists('Symfony\\Component\\Yaml\\Yaml')) {
             throw new \RuntimeException('Unable to read yaml as the Symfony Yaml Component is not installed.');
         }
-        $config = Yaml::parse($filename);
+        
+        $input = file_get_contents($filename); 
+        $config = Yaml::parse($input);
         return $config ?: array();
     }
 


### PR DESCRIPTION
As mentioned in the [symfony\yaml](https://github.com/symfony/Yaml/commit/a43656845f677a0f308f97667b2789410b67dc36) since 2.2:

"Passing a file as an input is a deprecated feature and will be removed in 3.0."
