### PR TITLE
Updates YAML driver to pass in file contents opposed to filename as per ...

### DIFF
--- a/src/Igorw/Silex/YamlConfigDriver.php
+++ b/src/Igorw/Silex/YamlConfigDriver.php
@@ -11,7 +11,7 @@ class YamlConfigDriver implements ConfigDriver
         if (!class_exists('Symfony\\Component\\Yaml\\Yaml')) {
             throw new \RuntimeException('Unable to read yaml as the Symfony Yaml Component is not installed.');
         }
-        $config = Yaml::parse($filename);
+        $config = Yaml::parse(file_get_contents($filename));
         return $config ?: array();
     }
 


### PR DESCRIPTION
...YAML deprecation plan.

In using the config service provider in our application, we are seeing deprecated warnings as the YAML::parse() method now expects the file contents, not the filename. YAML::parse has always supported passing in the file contents.

This pull request passes the packages phpunit tests. 
