### PR TITLE
Added a file_get_contents to the yaml driver

### DIFF
--- a/src/Igorw/Silex/YamlConfigDriver.php
+++ b/src/Igorw/Silex/YamlConfigDriver.php
@@ -11,7 +11,7 @@ class YamlConfigDriver implements ConfigDriver
         if (!class_exists('Symfony\\Component\\Yaml\\Yaml')) {
             throw new \RuntimeException('Unable to read yaml as the Symfony Yaml Component is not installed.');
         }
-        $config = Yaml::parse($filename);
+        $config = Yaml::parse(file_get_contents($filename));
         return $config ?: array();
     }
 


### PR DESCRIPTION
Added a file_get_contents to the yaml driver because symfony yaml 2.7 has deprecated the use of files and it is causing Deprecated warnings
