### PR TITLE
Don't Pass a Filename to Yaml::parse

### DIFF
--- a/src/Igorw/Silex/YamlConfigDriver.php
+++ b/src/Igorw/Silex/YamlConfigDriver.php
@@ -11,7 +11,8 @@ class YamlConfigDriver implements ConfigDriver
         if (!class_exists('Symfony\\Component\\Yaml\\Yaml')) {
             throw new \RuntimeException('Unable to read yaml as the Symfony Yaml Component is not installed.');
         }
-        $config = Yaml::parse($filename);
+
+        $config = Yaml::parse(file_get_contents($filename));
         return $config ?: array();
     }
 


### PR DESCRIPTION
Instead just `file_get_contents` the configuration file and pass the string to `Yaml::parse`.

Symfony 2.2 deprecated passing a filename into parse and Symfony 2.7 adds a deprecation warning to the method.
