### PR TITLE
Make the Yaml reader work with symfony/yaml 3.0

### DIFF
--- a/src/Igorw/Silex/YamlConfigDriver.php
+++ b/src/Igorw/Silex/YamlConfigDriver.php
@@ -11,7 +11,7 @@ class YamlConfigDriver implements ConfigDriver
         if (!class_exists('Symfony\\Component\\Yaml\\Yaml')) {
             throw new \RuntimeException('Unable to read yaml as the Symfony Yaml Component is not installed.');
         }
-        $config = Yaml::parse($filename);
+        $config = Yaml::parse(file_get_contents($filename));
         return $config ?: array();
     }
 


### PR DESCRIPTION
> The ability to pass file names to the parse method is deprecated since version 2.2 and will be removed in 3.0. Pass the YAML contents of the file instead.

(source https://github.com/symfony/yaml/blob/2.8/Yaml.php#L52)
