### PR TITLE
YAML and JSON parsing

### DIFF
--- a/src/Igorw/Silex/JsonConfigDriver.php
+++ b/src/Igorw/Silex/JsonConfigDriver.php
@@ -25,7 +25,7 @@ class JsonConfigDriver implements ConfigDriver
     private function parseJson($filename)
     {
         $json = file_get_contents($filename);
-        return json_decode($json, true);
+        return empty($json) ? [] : json_decode($json, true);
     }
 
     private function getJsonError($code)

--- a/src/Igorw/Silex/JsonConfigDriver.php
+++ b/src/Igorw/Silex/JsonConfigDriver.php
@@ -25,7 +25,7 @@ class JsonConfigDriver implements ConfigDriver
     private function parseJson($filename)
     {
         $json = file_get_contents($filename);
-        return empty($json) ? [] : json_decode($json, true);
+        return empty($json) ? array() : json_decode($json, true);
     }
 
     private function getJsonError($code)

--- a/src/Igorw/Silex/YamlConfigDriver.php
+++ b/src/Igorw/Silex/YamlConfigDriver.php
@@ -11,7 +11,7 @@ class YamlConfigDriver implements ConfigDriver
         if (!class_exists('Symfony\\Component\\Yaml\\Yaml')) {
             throw new \RuntimeException('Unable to read yaml as the Symfony Yaml Component is not installed.');
         }
-        $config = Yaml::parse($filename);
+        $config = Yaml::parse(file_get_contents($filename));
         return $config ?: array();
     }
 


### PR DESCRIPTION
Hello.
1. fixed YAML parsing (YAML::parse() accepts yaml content, not filename
2. fixed empty JSON parsing (json_decode throws error on empty json, added return of empty array for empty json to pass tests)
