### PR TITLE
Adding support for Silex 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
 
 php:
-  - 5.3.3
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,10 @@
         }
     ],
     "require": {
-        "silex/silex": "~1.0"
+        "silex/silex": "~2.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "^4.0",
         "symfony/yaml": "~2.1",
         "jamesmoss/toml": "~0.1"
     },

--- a/src/Igorw/Silex/ConfigServiceProvider.php
+++ b/src/Igorw/Silex/ConfigServiceProvider.php
@@ -11,8 +11,9 @@
 
 namespace Igorw\Silex;
 
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use Silex\Application;
-use Silex\ServiceProviderInterface;
 
 class ConfigServiceProvider implements ServiceProviderInterface
 {
@@ -40,7 +41,7 @@ class ConfigServiceProvider implements ServiceProviderInterface
         ));
     }
 
-    public function register(Application $app)
+    public function register(Container $app)
     {
         $config = $this->readConfig();
 

--- a/src/Igorw/Silex/JsonConfigDriver.php
+++ b/src/Igorw/Silex/JsonConfigDriver.php
@@ -6,10 +6,14 @@ class JsonConfigDriver implements ConfigDriver
 {
     public function load($filename)
     {
-        $config = $this->parseJson($filename);
+        $json = file_get_contents($filename);
+        $config = $this->parseJson($json);
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
-            $jsonError = $this->getJsonError(json_last_error());
+        // determine if there was an error
+        // suppress PHP 7's syntax error for empty JSON strings
+        $errorCode = json_last_error();
+        if (JSON_ERROR_NONE !== $errorCode && ($errorCode !== JSON_ERROR_SYNTAX || $json !== '')) {
+            $jsonError = $this->getJsonError($errorCode);
             throw new \RuntimeException(
                 sprintf('Invalid JSON provided "%s" in "%s"', $jsonError, $filename));
         }
@@ -22,9 +26,8 @@ class JsonConfigDriver implements ConfigDriver
         return (bool) preg_match('#\.json(\.dist)?$#', $filename);
     }
 
-    private function parseJson($filename)
+    private function parseJson($json)
     {
-        $json = file_get_contents($filename);
         return json_decode($json, true);
     }
 

--- a/src/Igorw/Silex/YamlConfigDriver.php
+++ b/src/Igorw/Silex/YamlConfigDriver.php
@@ -11,7 +11,7 @@ class YamlConfigDriver implements ConfigDriver
         if (!class_exists('Symfony\\Component\\Yaml\\Yaml')) {
             throw new \RuntimeException('Unable to read yaml as the Symfony Yaml Component is not installed.');
         }
-        $config = Yaml::parse($filename);
+        $config = Yaml::parse(file_get_contents($filename));
         return $config ?: array();
     }
 


### PR DESCRIPTION
Added Silex 2 support so I can bump OpenCFP up to Silex 2 (now that it's officially out). Also added phpunit to the composer.json (just because that's my preferred way to invoke it - I can back that out if that would be better). This does break Silex 1.0 compatibility, so it would probably be a good idea to bump the tag to 2.0 once committed. Resolves issue #54 
