### PR TITLE
Adding support for Silex 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ php:
   - 5.3.3
   - 5.3
   - 5.4
-  - 5.5
-  - 5.6
-  - hhvm
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: php
 
 php:
-  - 5.3.3
-  - 5.3
-  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_script:
   - composer self-update
   - composer install --dev --prefer-source
 
-script: phpunit --coverage-text
+script: vendor/bin/phpunit --coverage-text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+* [2.0.0] - 2017-04-24
+
+  * Upgrade to compatibility with Silex2
+
 * 1.2.2 (2014-07-06)
 
   * Feature: Configuration prefix (@desyncr)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,26 @@
+[![Build Status](https://travis-ci.org/youssman/ConfigServiceProvider.svg?branch=master)](https://travis-ci.org/youssman/ConfigServiceProvider)
+
+> This repo is a fork of the lib [igorw/ConfigServiceProvider](https://github.com/igorw/ConfigServiceProvider) bringing support for Silex2. A pull request was submitted but not yet accepted. 
+
 # ConfigServiceProvider
 
 A config ServiceProvider for [Silex](http://silex.sensiolabs.org) with support
 for php, json, yaml, and toml.
+
+## Installation
+
+Put these lines to your composer.json:
+
+    "require": {
+        "youssman/config-service-provider": "~2.0"
+    },
+    ...
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/youssman/ConfigServiceProvider"
+        }
+    ]  
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,12 @@
         }
     ],
     "require": {
-        "silex/silex": "~1.0"
+        "silex/silex": "~2.0"
     },
     "require-dev": {
         "symfony/yaml": "~2.1",
-        "jamesmoss/toml": "~0.1"
+        "jamesmoss/toml": "~0.1",
+        "phpunit/phpunit": "^6.0"
     },
     "suggest": {
         "symfony/yaml": "~2.1",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "igorw/config-service-provider",
-    "description": "A config ServiceProvider for Silex with support for php, json and yaml.",
-    "keywords": ["silex"],
+    "description": "A config ServiceProvider for Silex 2 with support for php, json and yaml.",
+    "keywords": ["silex 2", "php"],
     "license": "MIT",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "symfony/yaml": "~2.1",
         "jamesmoss/toml": "~0.1",
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^5.7.19"
     },
     "suggest": {
         "symfony/yaml": "~2.1",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "igorw/config-service-provider",
+    "name": "youssman/config-service-provider",
     "description": "A config ServiceProvider for Silex 2 with support for php, json and yaml.",
     "keywords": ["silex 2", "php"],
     "license": "MIT",

--- a/src/Igorw/Silex/ConfigServiceProvider.php
+++ b/src/Igorw/Silex/ConfigServiceProvider.php
@@ -11,17 +11,17 @@
 
 namespace Igorw\Silex;
 
-use Silex\Application;
-use Silex\ServiceProviderInterface;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 
 class ConfigServiceProvider implements ServiceProviderInterface
 {
     private $filename;
-    private $replacements = array();
+    private $replacements = [];
     private $driver;
     private $prefix = null;
 
-    public function __construct($filename, array $replacements = array(), ConfigDriver $driver = null, $prefix = null)
+    public function __construct($filename, array $replacements = [], ConfigDriver $driver = null, $prefix = null)
     {
         $this->filename = $filename;
         $this->prefix = $prefix;
@@ -32,40 +32,42 @@ class ConfigServiceProvider implements ServiceProviderInterface
             }
         }
 
-        $this->driver = $driver ?: new ChainConfigDriver(array(
+        $this->driver = $driver ?: new ChainConfigDriver([
             new PhpConfigDriver(),
             new YamlConfigDriver(),
             new JsonConfigDriver(),
             new TomlConfigDriver(),
-        ));
+        ]);
     }
 
-    public function register(Application $app)
+    public function register(Container $pimple)
     {
         $config = $this->readConfig();
 
-        foreach ($config as $name => $value)
-            if ('%' === substr($name, 0, 1))
-                $this->replacements[$name] = (string) $value;
+        foreach ($config as $name => $value) {
+            if ('%' === substr($name, 0, 1)) {
+                $this->replacements[$name] = preg_replace_callback(
+                    '/(%.+%)/U', function ($matches) use ($config) {
+                        return $this->replacements[$matches[0]];
+                    },
+                    (string) $value);
+            }
+        }
 
-        $this->merge($app, $config);
+        $this->merge($pimple, $config);
     }
 
-    public function boot(Application $app)
-    {
-    }
-
-    private function merge(Application $app, array $config)
+    private function merge(Container $pimple, array $config)
     {
         if ($this->prefix) {
-            $config = array($this->prefix => $config);
+            $config = [$this->prefix => $config];
         }
 
         foreach ($config as $name => $value) {
-            if (isset($app[$name]) && is_array($value)) {
-                $app[$name] = $this->mergeRecursively($app[$name], $value);
+            if (isset($pimple[$name]) && is_array($value)) {
+                $pimple[$name] = $this->mergeRecursively($pimple[$name], $value);
             } else {
-                $app[$name] = $this->doReplacements($value);
+                $pimple[$name] = $this->doReplacements($value);
             }
         }
     }

--- a/src/Igorw/Silex/JsonConfigDriver.php
+++ b/src/Igorw/Silex/JsonConfigDriver.php
@@ -6,10 +6,13 @@ class JsonConfigDriver implements ConfigDriver
 {
     public function load($filename)
     {
-        $config = $this->parseJson($filename);
-
-        if (JSON_ERROR_NONE !== json_last_error()) {
-            $jsonError = $this->getJsonError(json_last_error());
+        $json = file_get_contents($filename);
+        $config = $this->parseJson($json);
+        // determine if there was an error
+        // suppress PHP 7's syntax error for empty JSON strings
+        $errorCode = json_last_error();
+        if (JSON_ERROR_NONE !== $errorCode && ($errorCode !== JSON_ERROR_SYNTAX || $json !== '')) {
+            $jsonError = $this->getJsonError($errorCode);
             throw new \RuntimeException(
                 sprintf('Invalid JSON provided "%s" in "%s"', $jsonError, $filename));
         }
@@ -22,9 +25,8 @@ class JsonConfigDriver implements ConfigDriver
         return (bool) preg_match('#\.json(\.dist)?$#', $filename);
     }
 
-    private function parseJson($filename)
+    private function parseJson($json)
     {
-        $json = file_get_contents($filename);
         return json_decode($json, true);
     }
 

--- a/src/Igorw/Silex/YamlConfigDriver.php
+++ b/src/Igorw/Silex/YamlConfigDriver.php
@@ -11,7 +11,7 @@ class YamlConfigDriver implements ConfigDriver
         if (!class_exists('Symfony\\Component\\Yaml\\Yaml')) {
             throw new \RuntimeException('Unable to read yaml as the Symfony Yaml Component is not installed.');
         }
-        $config = Yaml::parse($filename);
+        $config = Yaml::parse(file_get_contents($filename));
         return $config ?: array();
     }
 

--- a/tests/integration/ConfigServiceProviderTest.php
+++ b/tests/integration/ConfigServiceProviderTest.php
@@ -185,7 +185,7 @@ class ConfigServiceProviderTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Invalid JSON provided 'Syntax error' in
+     * @expectedExceptionMessage Invalid JSON provided "Syntax error" in
      */
     public function invalidJsonShouldThrowException()
     {

--- a/tests/integration/ConfigServiceProviderTest.php
+++ b/tests/integration/ConfigServiceProviderTest.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-use Silex\Application;
 use Igorw\Silex\ConfigServiceProvider;
+use Silex\Application;
 
 /**
  * @author Igor Wiedler <igor@wiedler.ch>
  * @author Jérôme Macias <jerome.macias@gmail.com>
  */
-class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
+class ConfigServiceProviderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider provideFilenames
@@ -27,7 +27,7 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $app->register(new ConfigServiceProvider($filename));
 
-        $this->assertSame(true, $app['debug']);
+        $this->assertTrue($app['debug']);
         $this->assertSame('%data%', $app['data']);
     }
 
@@ -38,9 +38,9 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->register(new ConfigServiceProvider($filename, array(
-            'data' => 'test-replacement'
-        )));
+        $app->register(new ConfigServiceProvider($filename, [
+            'data' => 'test-replacement',
+        ]));
 
         $this->assertSame(true, $app['debug']);
         $this->assertSame('test-replacement', $app['data']);
@@ -54,8 +54,8 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
         $readConfigMethod = new \ReflectionMethod('Igorw\Silex\ConfigServiceProvider', 'readConfig');
         $readConfigMethod->setAccessible(true);
 
-        $this->assertEquals(
-            array(),
+        $this->assertSame(
+            [],
             $readConfigMethod->invoke(new ConfigServiceProvider($filename))
         );
     }
@@ -83,8 +83,8 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $filenameBase = __DIR__."/Fixtures/config_base.toml";
-        $filenameExtended = __DIR__."/Fixtures/config_extend.toml";
+        $filenameBase = __DIR__.'/Fixtures/config_base.toml';
+        $filenameExtended = __DIR__.'/Fixtures/config_extend.toml';
 
         $app->register(new ConfigServiceProvider($filenameBase));
         $app->register(new ConfigServiceProvider($filenameExtended));
@@ -99,10 +99,10 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('123', $app['myproject']['param1']);
         $this->assertSame('456', $app['myproject']['param2']);
         $this->assertSame('456', $app['myproject']['param3']);
-        $this->assertSame(array(4, 5, 6), $app['myproject']['param4']);
+        $this->assertSame([4, 5, 6], $app['myproject']['param4']);
         $this->assertSame('456', $app['myproject']['param5']);
 
-        $this->assertSame(array(1, 2, 3, 4), $app['keys']['set']);
+        $this->assertSame([1, 2, 3, 4], $app['keys']['set']);
     }
 
     /**
@@ -111,7 +111,7 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
     public function testConfigWithPrefix($filename)
     {
         $app = new Application();
-        $app->register(new ConfigServiceProvider($filename, array(), null, 'prefix'));
+        $app->register(new ConfigServiceProvider($filename, [], null, 'prefix'));
         $this->assertNotNull($app['prefix']);
         $this->assertSame(true, $app['prefix']['debug']);
         $this->assertSame('%data%', $app['prefix']['data']);
@@ -123,8 +123,8 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
     public function testMergeConfigsWithPrefix($filenameBase, $filenameExtended)
     {
         $app = new Application();
-        $app->register(new ConfigServiceProvider($filenameBase, array(), null, 'prefix'));
-        $app->register(new ConfigServiceProvider($filenameExtended, array(), null, 'prefix'));
+        $app->register(new ConfigServiceProvider($filenameBase, [], null, 'prefix'));
+        $app->register(new ConfigServiceProvider($filenameExtended, [], null, 'prefix'));
 
         $this->assertNotNull($app['prefix']);
 
@@ -133,9 +133,9 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('123', $app['prefix']['myproject.test']['param1']);
         $this->assertSame('123', $app['prefix']['myproject.test']['param3']['param2A']);
-        $this->assertSame(array(4, 5, 6), $app['prefix']['myproject.test']['param4']);
+        $this->assertSame([4, 5, 6], $app['prefix']['myproject.test']['param4']);
 
-        $this->assertSame(array(1,2,3,4), $app['prefix']['test.noparent.key']['test']);
+        $this->assertSame([1,2,3,4], $app['prefix']['test.noparent.key']['test']);
     }
 
     /**
@@ -144,15 +144,15 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
     public function testConfigsWithMultiplePrefixes($filenameBase, $filenameExtended)
     {
         $app = new Application();
-        $app->register(new ConfigServiceProvider($filenameBase, array(), null, 'base'));
-        $app->register(new ConfigServiceProvider($filenameExtended, array(), null, 'extended'));
+        $app->register(new ConfigServiceProvider($filenameBase, [], null, 'base'));
+        $app->register(new ConfigServiceProvider($filenameExtended, [], null, 'extended'));
 
         $this->assertSame(null, $app['extended']['db.options']['password']);
         $this->assertSame('123', $app['base']['myproject.test']['param1']);
         $this->assertSame('123', $app['base']['myproject.test']['param3']['param2A']);
-        $this->assertSame(array(4, 5, 6), $app['extended']['myproject.test']['param4']);
+        $this->assertSame([4, 5, 6], $app['extended']['myproject.test']['param4']);
 
-        $this->assertSame(array(1,2,3,4), $app['extended']['test.noparent.key']['test']);
+        $this->assertSame([1,2,3,4], $app['extended']['test.noparent.key']['test']);
     }
 
     /**
@@ -176,31 +176,31 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('123', $app['myproject.test']['param3']['param2A']);
         $this->assertSame('456', $app['myproject.test']['param3']['param2B']);
         $this->assertSame('456', $app['myproject.test']['param3']['param2C']);
-        $this->assertSame(array(4, 5, 6), $app['myproject.test']['param4']);
+        $this->assertSame([4, 5, 6], $app['myproject.test']['param4']);
         $this->assertSame('456', $app['myproject.test']['param5']);
 
-        $this->assertSame(array(1,2,3,4), $app['test.noparent.key']['test']);
+        $this->assertSame([1,2,3,4], $app['test.noparent.key']['test']);
     }
 
     /**
      * @test
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Invalid JSON provided "Syntax error" in
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Invalid JSON provided 'Syntax error' in
      */
     public function invalidJsonShouldThrowException()
     {
         $app = new Application();
-        $app->register(new ConfigServiceProvider(__DIR__."/Fixtures/broken.json"));
+        $app->register(new ConfigServiceProvider(__DIR__.'/Fixtures/broken.json'));
     }
 
     /**
      * @test
-     * @expectedException Symfony\Component\Yaml\Exception\ParseException
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
      */
     public function invalidYamlShouldThrowException()
     {
         $app = new Application();
-        $app->register(new ConfigServiceProvider(__DIR__."/Fixtures/broken.yml"));
+        $app->register(new ConfigServiceProvider(__DIR__.'/Fixtures/broken.yml'));
     }
 
     /**
@@ -210,45 +210,45 @@ class ConfigServiceProviderTest extends \PHPUnit_Framework_TestCase
     public function invalidTomlShouldThrowException()
     {
         $app = new Application();
-        $app->register(new ConfigServiceProvider(__DIR__."/Fixtures/broken.toml"));
+        $app->register(new ConfigServiceProvider(__DIR__.'/Fixtures/broken.toml'));
     }
 
     public function provideFilenames()
     {
-        return array(
-            array(__DIR__."/Fixtures/config.php"),
-            array(__DIR__."/Fixtures/config.json"),
-            array(__DIR__."/Fixtures/config.yml"),
-            array(__DIR__."/Fixtures/config.toml"),
-        );
+        return [
+            [__DIR__.'/Fixtures/config.php'],
+            [__DIR__.'/Fixtures/config.json'],
+            [__DIR__.'/Fixtures/config.yml'],
+            [__DIR__.'/Fixtures/config.toml'],
+        ];
     }
 
     public function provideReplacementFilenames()
     {
-        return array(
-            array(__DIR__."/Fixtures/config_replacement.php"),
-            array(__DIR__."/Fixtures/config_replacement.json"),
-            array(__DIR__."/Fixtures/config_replacement.yml"),
-            array(__DIR__."/Fixtures/config_replacement.toml"),
-        );
+        return [
+            [__DIR__.'/Fixtures/config_replacement.php'],
+            [__DIR__.'/Fixtures/config_replacement.json'],
+            [__DIR__.'/Fixtures/config_replacement.yml'],
+            [__DIR__.'/Fixtures/config_replacement.toml'],
+        ];
     }
 
     public function provideEmptyFilenames()
     {
-        return array(
-            array(__DIR__."/Fixtures/config_empty.php"),
-            array(__DIR__."/Fixtures/config_empty.json"),
-            array(__DIR__."/Fixtures/config_empty.yml"),
-            array(__DIR__."/Fixtures/config_empty.toml"),
-        );
+        return [
+            [__DIR__.'/Fixtures/config_empty.php'],
+            [__DIR__.'/Fixtures/config_empty.json'],
+            [__DIR__.'/Fixtures/config_empty.yml'],
+            [__DIR__.'/Fixtures/config_empty.toml'],
+        ];
     }
 
     public function provideMergeFilenames()
     {
-        return array(
-            array(__DIR__."/Fixtures/config_base.php", __DIR__."/Fixtures/config_extend.php"),
-            array(__DIR__."/Fixtures/config_base.json", __DIR__."/Fixtures/config_extend.json"),
-            array(__DIR__."/Fixtures/config_base.yml", __DIR__."/Fixtures/config_extend.yml"),
-        );
+        return [
+            [__DIR__.'/Fixtures/config_base.php', __DIR__.'/Fixtures/config_extend.php'],
+            [__DIR__.'/Fixtures/config_base.json', __DIR__.'/Fixtures/config_extend.json'],
+            [__DIR__.'/Fixtures/config_base.yml', __DIR__.'/Fixtures/config_extend.yml'],
+        ];
     }
 }

--- a/tests/integration/Fixtures/config.php
+++ b/tests/integration/Fixtures/config.php
@@ -1,6 +1,6 @@
 <?php
 
-return array(
+return [
     'debug' => true,
     'data'  => '%data%',
-);
+];

--- a/tests/integration/Fixtures/config_base.php
+++ b/tests/integration/Fixtures/config_base.php
@@ -1,18 +1,18 @@
 <?php
 
-return array(
-    'db.options' => array(
+return [
+    'db.options' => [
         'driver' => 'pdo_mysql',
         'charset' => 'utf8',
-    ),
-    'myproject.test' => array(
+    ],
+    'myproject.test' => [
         'param1' => '123',
         'param2' => '123',
-        'param3' => array(
+        'param3' => [
             'param2A' => '123',
             'param2B' => '123',
-        ),
-        'param4' => array(1, 2, 3),
-     ),
-     'test.noparent.key' => array(),
-);
+        ],
+        'param4' => [1, 2, 3],
+     ],
+     'test.noparent.key' => [],
+];

--- a/tests/integration/Fixtures/config_extend.php
+++ b/tests/integration/Fixtures/config_extend.php
@@ -1,22 +1,22 @@
 <?php
 
-return array(
-    'db.options' => array(
+return [
+    'db.options' => [
         'host' => '127.0.0.1',
         'dbname' => 'mydatabase',
         'user' => 'root',
         'password' => NULL,
-    ),
-    'myproject.test' => array(
+    ],
+    'myproject.test' => [
         'param2' => '456',
-        'param3' => array(
+        'param3' => [
             'param2B' => '456',
             'param2C' => '456',
-        ),
-        'param4' => array(4, 5, 6),
+        ],
+        'param4' => [4, 5, 6],
         'param5' => '456',
-    ),
-    'test.noparent.key' => array(
-        'test' => array(1, 2, 3, 4),
-    ),
-);
+    ],
+    'test.noparent.key' => [
+        'test' => [1, 2, 3, 4],
+    ],
+];

--- a/tests/integration/Fixtures/config_replacement.php
+++ b/tests/integration/Fixtures/config_replacement.php
@@ -1,9 +1,9 @@
 <?php
 
-return array(
+return [
     '%path%'        => '/var/www',
     'path.images'   => '%path%/web/images',
     'path.upload'   => '%path%/upload',
     '%url%'         => 'http://example.com',
     'url.images'    => '%url%/images',
-);
+];

--- a/tests/unit/ConfigServiceProviderTest.php
+++ b/tests/unit/ConfigServiceProviderTest.php
@@ -15,35 +15,35 @@ namespace Igorw\Silex;
  * @author Igor Wiedler <igor@wiedler.ch>
  * @author Jérôme Macias <jerome.macias@gmail.com>
  */
-class GetFileFormatTest extends \PHPUnit_Framework_TestCase
+class GetFileFormatTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider provideFilenamesForFormat
      */
     public function testGetFileFormat($filename)
     {
-        $driver = new ChainConfigDriver(array(
+        $driver = new ChainConfigDriver([
             new PhpConfigDriver(),
             new YamlConfigDriver(),
             new JsonConfigDriver(),
             new TomlConfigDriver(),
-        ));
+        ]);
 
         $this->assertTrue($driver->supports($filename));
     }
 
     public function provideFilenamesForFormat()
     {
-        return array(
-            'yaml'      => array(__DIR__."/Fixtures/config.yaml"),
-            'yml'       => array(__DIR__."/Fixtures/config.yml"),
-            'yaml.dist' => array(__DIR__."/Fixtures/config.yaml.dist"),
-            'json'      => array(__DIR__."/Fixtures/config.json"),
-            'json.dist' => array(__DIR__."/Fixtures/config.json.dist"),
-            'php'       => array(__DIR__."/Fixtures/config.php"),
-            'php.dist'  => array(__DIR__."/Fixtures/config.php.dist"),
-            'toml'      => array(__DIR__."/Fixtures/config.toml"),
-            'toml.dist' => array(__DIR__."/Fixtures/config.toml.dist"),
-        );
+        return [
+            'yaml'      => [__DIR__.'/Fixtures/config.yaml'],
+            'yml'       => [__DIR__.'/Fixtures/config.yml'],
+            'yaml.dist' => [__DIR__.'/Fixtures/config.yaml.dist'],
+            'json'      => [__DIR__.'/Fixtures/config.json'],
+            'json.dist' => [__DIR__.'/Fixtures/config.json.dist'],
+            'php'       => [__DIR__.'/Fixtures/config.php'],
+            'php.dist'  => [__DIR__.'/Fixtures/config.php.dist'],
+            'toml'      => [__DIR__.'/Fixtures/config.toml'],
+            'toml.dist' => [__DIR__.'/Fixtures/config.toml.dist'],
+        ];
     }
 }


### PR DESCRIPTION
Added Silex 2 support. 
Added phpunit to the composer.json. 
This breaks Silex 1.0 compatibility, so the tag is set to 2.0 once committed. 
Resolves issue #54
Removes dependence on Silex\Application